### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/analytics/target/streams/$global/assemblyOption/$global/streams/assembly/17ad162f7a0d2c58609c60bff17891554b3d665d_761ea405b9b37ced573d2df0d1e3a4e0f9edc668/META-INF/maven/commons-collections/commons-collections/pom.xml
+++ b/analytics/target/streams/$global/assemblyOption/$global/streams/assembly/17ad162f7a0d2c58609c60bff17891554b3d665d_761ea405b9b37ced573d2df0d1e3a4e0f9edc668/META-INF/maven/commons-collections/commons-collections/pom.xml
@@ -27,7 +27,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>commons-collections</groupId>
   <artifactId>commons-collections</artifactId>
-  <version>3.2.1</version>
+  <version>3.2.2</version>
   <name>Commons Collections</name>
 
   <inceptionYear>2001</inceptionYear>

--- a/analytics/target/streams/$global/assemblyOption/$global/streams/assembly/ed9c84714da9acbc58ffd250b9bbb30f58c2459d_f37dc290664aab3c73fd5f9f97bad841eb10cfe2/META-INF/maven/ua_parser/ua-parser/pom.xml
+++ b/analytics/target/streams/$global/assemblyOption/$global/streams/assembly/ed9c84714da9acbc58ffd250b9bbb30f58c2459d_f37dc290664aab3c73fd5f9f97bad841eb10cfe2/META-INF/maven/ua_parser/ua-parser/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
